### PR TITLE
Support for macOS

### DIFF
--- a/BokenEngine.xcodeproj/project.pbxproj
+++ b/BokenEngine.xcodeproj/project.pbxproj
@@ -214,13 +214,15 @@
 			attributes = {
 				LastSwiftUpdateCheck = 1010;
 				LastUpgradeCheck = 1010;
-				ORGANIZATIONNAME = Hyve;
+				ORGANIZATIONNAME = "The Boken Engine Team";
 				TargetAttributes = {
 					5D0DF6EA25B056B80099F811 = {
 						CreatedOnToolsVersion = 10.1;
+						LastSwiftMigration = 1250;
 					};
 					5D0DF6F325B056B90099F811 = {
 						CreatedOnToolsVersion = 10.1;
+						LastSwiftMigration = 1250;
 					};
 				};
 			};
@@ -230,6 +232,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 5D0DF6E125B056B80099F811;
 			productRefGroup = 5D0DF6EC25B056B80099F811 /* Products */;
@@ -457,7 +460,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = QF53849G49;
+				DEVELOPMENT_TEAM = 3J6NF29UZL;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -471,8 +474,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.hyve.boken-engine";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,6";
 			};
 			name = Debug;
 		};
@@ -482,7 +486,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = QF53849G49;
+				DEVELOPMENT_TEAM = 3J6NF29UZL;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -496,8 +500,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.hyve.boken-engine";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,6";
 			};
 			name = Release;
 		};
@@ -506,7 +511,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = QF53849G49;
+				DEVELOPMENT_TEAM = 3J6NF29UZL;
 				INFOPLIST_FILE = BokenEngineTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -515,7 +520,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.hyve.MeinFrameworkTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -525,7 +530,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = QF53849G49;
+				DEVELOPMENT_TEAM = 3J6NF29UZL;
 				INFOPLIST_FILE = BokenEngineTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -534,7 +539,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.hyve.MeinFrameworkTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/BokenEngine/Classes/Utils.swift
+++ b/BokenEngine/Classes/Utils.swift
@@ -33,11 +33,15 @@ func getDeviceRelativeCoordinates(view: SKView, posX: Float, posY: Float) -> CGP
 }
 
 func getDeviceOrientation() -> DeviceOrientation {
+    #if targetEnvironment(macCatalyst)
+        return DeviceOrientation.horizontal
+    #else
     if UIApplication.shared.statusBarOrientation.isLandscape {
         return DeviceOrientation.horizontal
     } else {
         return DeviceOrientation.vertical
     }
+    #endif
 }
 
 func isLandscapeMode() -> Bool {

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 An iOS Swift framework for creating slides-based, non-linear visual stories and presentations.
 
+https://boken-engine.dev
+
 ## 1. Description
 
 BOKEN (from Swedish: The Book; also from Japanese 冒険 - Bōken: Adventure) ENGINE is a Swift Framework with which any user, only with a few lines of codes, can generate full fledged visual stories or slide based presentations for iOS devices. It is based on SpriteKit.


### PR DESCRIPTION
There was only 1 warning trying to build for macOS and for the time being I solved with a condition at build time:

```
    #if targetEnvironment(macCatalyst)
        return DeviceOrientation.horizontal
    #else
```

I have also upgraded to Swift 5 and changed the development team because I'm the one who is publishing the demo app on the Apple Store.