### PR TITLE
Fix deprecated `instruments` command

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Show xcodebuild version
         run: xcodebuild -version
@@ -65,7 +65,7 @@ jobs:
   SwiftLint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: GitHub Action for SwiftLint
         uses: norio-nomura/action-swiftlint@3.2.1
   Tailor:
@@ -76,7 +76,7 @@ jobs:
           brew update
           brew install tailor   
       - name: Checkout
-        uses: actions/checkout@v2          
+        uses: actions/checkout@v3      
       - name: Static analysis using Tailor
         run: tailor .
   Lizard:
@@ -85,6 +85,6 @@ jobs:
       - name: Install Lizard
         run: pip install lizard      
       - name: Checkout
-        uses: actions/checkout@v2          
+        uses: actions/checkout@v3  
       - name: Code quality using Lizard
         run: lizard

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -39,7 +39,7 @@ jobs:
           platform: ${{ 'iOS Simulator' }}
         run: |
           # 1. Get the list of available iPhone simulators, and get the first one
-          device=`instruments -s -devices | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}'`
+          device=`xcrun xctrace list devices | grep -oE 'iPhone.*?[^\(]+' | sed -e "s/ Simulator//" | head -1 | awk '{$1=$1;print}'`
           
           # 2. Set the default scheme and target if selected on the previously step
           if [ $scheme = default ]; then scheme=$(cat default); fi
@@ -53,7 +53,7 @@ jobs:
           platform: ${{ 'iOS Simulator' }}
         run: |
           # 1. Get the list of available iPhone simulators, and get the first one
-          device=`instruments -s -devices | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}'`
+          device=`xcrun xctrace list devices | grep -oE 'iPhone.*?[^\(]+' | sed -e "s/ Simulator//" | head -1 | awk '{$1=$1;print}'`
           
           # 2. Set the default scheme and target if selected on the previously step
           if [ $scheme = default ]; then scheme=$(cat default); fi

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Show xcodebuild version
+        run: xcodebuild -version
+
       - name: Set Default Scheme
         run: |
           # 1. Get available schemes in the project

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,9 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+# Mac OS X
+.DS_Store
+
+# Swift Package Manager
+.swiftpm/

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
-          "version": "1.0.0"
+          "revision": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+          "version": "1.0.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
-          "version": "0.9.2"
+          "revision": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+          "version": "0.10.1"
         }
       }
     ]


### PR DESCRIPTION
The command we use to get the list of available iPhone simulators is deprecated:

```s
% instruments -s -devices
`instruments` is now deprecated in favor of 'xcrun xctrace' (see `man xctrace` for more information on its replacement)
Known Devices:
...
```

As the output says we can use:

```s
xcrun xctrace list devices
```